### PR TITLE
fix an unbounded pointer scan

### DIFF
--- a/src/os/linux/linux_sigar.c
+++ b/src/os/linux/linux_sigar.c
@@ -1196,7 +1196,7 @@ static int get_iostat_sys(sigar_t *sigar,
         name += SSTRLEN(SIGAR_DEV_PREFIX); /* strip "/dev/" */
     }
 
-    while (!sigar_isdigit(*fsdev)) {
+    while (!sigar_isdigit(*fsdev) && *fsdev != '\0') {
         fsdev++;
     }
 


### PR DESCRIPTION
This fixes an unbounded pointer scan for a digit. Apparently some kernels return `/dev/pts` instead of `/dev/pts/0` for some IO devices.