### PR TITLE
Include sysmacros for major/minor system functions

### DIFF
--- a/src/os/linux/sigar_os.h
+++ b/src/os/linux/sigar_os.h
@@ -29,6 +29,9 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#ifdef HAVE_SYSMACROS_H
+#include <sys/sysmacros.h>
+#endif
 
 typedef struct {
     sigar_pid_t pid;


### PR DESCRIPTION
Without this the Ubuntu 18.10 build was giving the compiler error:

```
/data/buildslave/agent2-ubuntu1810-x86_64/build/src/luvi-rackspace/deps/lua-sigar/deps/sigar/src/os/linux/linux_sigar.c:1178:22: error: called object ‘minor’ is not a function or function pointer
 #define ST_MINOR(sb) minor((sb).st_rdev)
                      ^~~~~
```

There will be a companion PR in virgo-agent-toolkit/luvi to enable the `HAVE_SYSMACROS_H` flag.